### PR TITLE
Add Docker support for containerized deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use lightweight Node image
+FROM node:18-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Copy all files to container
+COPY . .
+
+# Install serve globally to serve static files
+RUN npm install -g serve
+
+# Command to run the app
+CMD ["serve", "-s", ".", "-l", "5000"]
+
+# Expose port 5000
+EXPOSE 5000

--- a/README.md
+++ b/README.md
@@ -44,3 +44,18 @@ A clean, responsive, and lightweight to-do list application built with **HTML**,
    ```bash
    git clone https://github.com/mangosain/Simple-To-Do-List.git
    ```
+2. Running with Docker:
+
+You can run this app anywhere using Docker.
+
+**Build Docker Image**
+```bash
+docker build -t todo-app .
+```
+**Run Container**
+```bash
+docker run -p 5000:5000 todo-app
+```
+Open your browser at http://localhost:5000 to see the app.
+
+**Note:** Make sure Docker is installed and running.


### PR DESCRIPTION
This PR adds Docker support to the Simple-To-Do-List app.

- Dockerfile added to containerize the app
- README updated with instructions to build and run using Docker
- App can now run anywhere with Docker, no local setup required
- This contribution is part of Hacktoberfest 2025
